### PR TITLE
Improve HTSlib finding

### DIFF
--- a/C/Cmakes/Findhtslib.cmake
+++ b/C/Cmakes/Findhtslib.cmake
@@ -7,7 +7,6 @@
 
 set(HTSLIB_SEARCH_DIRS
         ${HTSLIB_SEARCH_DIRS}
-        $ENV{HTLSIB_ROOT}
         /gsc/pkg/bio/htslib
         /usr
         /usr/local
@@ -34,7 +33,6 @@ find_path(HTSlib_INCLUDE_DIR
 find_library(HTSlib_LIBRARY
         NAMES hts libhts.a hts.a
         PATHS ${HTSlib_INCLUDE_DIR} ${HTSLIB_SEARCH_DIRS}
-        NO_DEFAULT_PATH
         PATH_SUFFIXES lib lib64 ${_htslib_ver_path} htslib
         HINTS ENV HTSLIB_ROOT
         HINTS ENV HTSLIB_DIR


### PR DESCRIPTION
- Adding the HTSLIB_ROOT to HTSLIB_SEARCH_DIRS is superfluous as
HTSLIB_ROOT are already hints (also there's a typo)

- Removed NO_DEFAULT_PATH as this prevents finding the libraries
(headers still found correctly) when they are not part of the
listed search paths. Without this option the libraries are found
on systems where the HTSLIBs are stored at alternative locations.
