### PR TITLE
Absolute path in multiparse fix

### DIFF
--- a/Python/multiparse.py
+++ b/Python/multiparse.py
@@ -85,7 +85,7 @@ def write_file(queue, motif_csv_out_path, sample_csv_out_path, manifest_path):
                 print("Fail to read manifest on line: ")
                 print(line)
             group_dict[spline[0]] = spline[3]
-            name_dict[spline[2]] = spline[0]
+            name_dict[os.path.abspath(spline[2])] = spline[0]
     while True:
         case = queue.get()
         # print("Printcase: " + case[0] + "\t" + str(case[1]) + "\tdictlen: " + str(len(case[2])))


### PR DESCRIPTION
There is an absolute path missing in the multiparse script. This leads to an missing key error when using relative pathes in the manifest.