### PR TITLE
Update screen.py to not skip when one group is entirely zeros but there is data in a second group

### DIFF
--- a/Python/screen.py
+++ b/Python/screen.py
@@ -77,8 +77,7 @@ def score_df(motif, f_path, manifest_df, control_label, n_trials,
             continue
         cases = current_data.loc[current_data["grp"] == targ]["info_score"]
         controls = current_data.loc[current_data["grp"] != targ]["info_score"]
-        if len(cases) == 0 or len(controls) == 0 or sum(cases) == 0.0 or sum(
-                controls) == 0.0:
+        if len(cases) == 0 or len(controls) == 0 or (sum(cases) == 0.0 and sum(controls) == 0.0):
             continue
         mann_whitney_stat, mann_whitney_p = mannwhitneyu(cases, controls,
                                                          alternative="greater")


### PR DESCRIPTION
The current version of superSTR skips running the mann-whitney test if one of the groups is all zeroes, i.e the weighted information score for each sample looks like

cases = [4.463641e-05, 4.174111e-05, 3.779060e-05, 1.215081e-05, 5.684518e-05] 
controls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
In this case you couldn’t use an exact test since there are ties but you can still get a result using asymptotics and in my opinion it makes sense for this example that the test shouldn’t be skipped since there is data for one group (i.e an expansion in diseease groups but not controls).